### PR TITLE
Prebuilt multi-arch GHCR images + standalone compose (Tiers Phase 1 + 2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# The backend image is built from the REPO ROOT (see backend/Dockerfile) so it can bake
+# in scripts/ + config/ for the standalone compose's first-run demo seed. This file keeps
+# everything the backend image does NOT need out of that build context. It does NOT affect
+# the frontend image (built with context ./frontend, governed by frontend/.dockerignore).
+#
+# Do NOT add scripts/, config/, or backend/ here — those are intentionally baked in.
+
+# VCS / CI / infra not needed inside the image
+.git/
+.github/
+.gitignore
+.gitattributes
+docs/
+*.md
+docker-compose*.yml
+
+# Frontend has its own image + build context
+frontend/
+
+# Python build artifacts / virtualenvs — the image builds its own Linux .venv
+**/.venv/
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/*.pyd
+**/.pytest_cache/
+**/.ruff_cache/
+**/.mypy_cache/
+
+# Node — never relevant to the backend image
+**/node_modules/
+
+# Secrets / runtime artifacts — must never be baked into a layer
+**/.env
+**/.env.*
+.env
+.env.*
+**/.monarch_session
+**/*.log
+**/.DS_Store

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,93 @@
+name: Build & Push Docker Images
+
+# Builds multi-arch (linux/amd64 + linux/arm64) images for the backend and frontend
+# and pushes them to GHCR, so users `docker compose pull` (~30-60s) instead of building
+# locally (~3-5 min) and never hit architecture surprises. This is Phase 1 of the
+# distribution-tiers plan (strategy/TIERS_PLAN.md) and the technical foundation for the
+# free tier — public images need no GitHub account to pull.
+#
+# Post-merge one-time steps (the workflow CANNOT do these — they're account settings):
+#   1. Watch the first run at github.com/gdb-mtx/fire-master/actions
+#   2. Make BOTH GHCR packages public: GitHub profile -> Packages -> each package ->
+#      Settings -> Change visibility -> Public (enables unauthenticated pulls)
+#   3. Test a fresh checkout + `docker compose up` — verify it PULLS, not builds.
+
+on:
+  push:
+    branches: [main]
+    # Only rebuild when something that lands in an image (or this workflow) changes.
+    # scripts/ + config/ are listed because they are now baked into the backend image.
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'scripts/**'
+      - 'config/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/docker-images.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write   # required for docker/login-action to push to GHCR via GITHUB_TOKEN
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Two parallel jobs, one per image. fail-fast: false so a frontend failure doesn't
+    # cancel an in-flight backend build (and vice versa).
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The backend build context is the REPO ROOT (not ./backend) so the image can
+          # bake in the repo-root scripts/ + config/ dirs the standalone compose needs
+          # for its first-run demo seed. See backend/Dockerfile.
+          - name: backend
+            context: .
+            dockerfile: backend/Dockerfile
+            image: ghcr.io/gdb-mtx/firemaster-backend
+          - name: frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+            image: ghcr.io/gdb-mtx/firemaster-frontend
+    name: build-${{ matrix.name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags & labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          # latest (default branch only), sha-<7char>, and a YYYY.MM.DD date tag.
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value={{date 'YYYY.MM.DD'}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Per-image GHA layer cache (scoped so backend/frontend don't evict each other).
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/README.md
+++ b/README.md
@@ -62,14 +62,15 @@ gh auth login                                         # GitHub.com → HTTPS →
 gh repo clone gdb-mtx/fire-master firemaster && cd firemaster
 
 docker compose run --rm backend uv run python -m app.setup   # one-time: JWT secret + your admin password
-docker compose up                                     # builds + starts everything; migrations + demo data load automatically
+docker compose up                                     # pulls prebuilt images + starts everything; migrations + demo data load automatically
 ```
 
 Open **http://localhost:5173** and log in as `admin` with the password you chose — the **demo
 persona is already loaded**, so every page (Dashboard, Retirement, Runway, Config) is alive on
 first launch.
 
-> **First run builds images and can take a few minutes**; subsequent `docker compose up` is fast.
+> **First run pulls prebuilt multi-arch images from GHCR (~30–60s)**; subsequent `docker compose up` is faster still.
+> (No prebuilt image yet, or offline? `docker compose up --build` builds locally instead.) To update later: `docker compose pull && docker compose up -d`.
 > A `migrate` container that shows `Exited (0)` is normal — it applied migrations + seeded the demo, then quit.
 > If `:5432`/`:6379`/`:8000`/`:5173` are already taken, set e.g.
 > `BACKEND_HOST_PORT=8001 FRONTEND_HOST_PORT=5174` before the command. Operational details,

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,14 +10,24 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app/backend
 
+# NOTE: this image is built with the REPO ROOT as the build context (see
+# docker-compose.yml and .github/workflows/docker-images.yml), NOT ./backend. That lets
+# the image bake in the repo-root scripts/ + config/ dirs, which the standalone
+# (no-bind-mount) docker-compose.public.yml needs for its first-run demo seed.
+# A root .dockerignore keeps the rest of the repo (frontend, .git, venvs, secrets) out.
+
 # Copy dependency files first for layer caching
-COPY pyproject.toml uv.lock* ./
+COPY backend/pyproject.toml backend/uv.lock* ./
 
 # Install dependencies
 RUN uv sync --frozen --no-dev 2>/dev/null || uv sync
 
-# Copy application code
-COPY . .
+# Application code into /app/backend, plus the seed scripts and config the demo seed
+# reads. scripts/seed_*.py expect <repo>/backend as a sibling dir — here that's
+# /app/backend, so `python ../scripts/seed_demo.py` from WORKDIR resolves correctly.
+COPY backend/ ./
+COPY scripts /app/scripts
+COPY config /app/config
 
 EXPOSE 8000
 

--- a/docker-compose.public.yml
+++ b/docker-compose.public.yml
@@ -1,0 +1,147 @@
+# Standalone (no-clone) compose for the free/paid tiers — Phase 2 of strategy/TIERS_PLAN.md.
+#
+# This is the file shipped in the install kit (firemaster.io), NOT the dev compose. It pulls
+# the prebuilt GHCR images and runs the whole stack with NO source-code checkout: no `build:`
+# directives, no Dockerfiles, no scripts/ or config/ on disk (they're baked into the backend
+# image). The only thing on the user's machine is this file plus a backend/.env.
+#
+# First-run flow (see the install-kit guide):
+#   1. docker compose -f docker-compose.public.yml run --rm backend uv run python -m app.setup
+#        -> writes backend/.env (JWT secret + admin password hash)
+#   2. docker compose -f docker-compose.public.yml up
+#        -> pulls images (~30-60s), migrates, auto-seeds the demo, starts everything
+#   3. open http://localhost:5173
+#
+# Staying current:  docker compose -f docker-compose.public.yml pull && \
+#                   docker compose -f docker-compose.public.yml up -d
+#
+# IMPORTANT — the .env mount:
+#   The four backend services bind-mount the single file ./backend/.env into the container
+#   (NOT an `env_file:` — Compose interpolates env_file values and strips the `$` out of the
+#   bcrypt hash, breaking login; the app reads the mounted file directly via pydantic). A
+#   Docker bind mount of a path that does NOT exist on the host is created as a *directory*,
+#   which breaks `app.setup`. So the install kit must ship an (empty) backend/.env placeholder,
+#   and the setup step in (1) above fills it in. Do not delete the placeholder.
+#
+# Monarch sync is intentionally NOT wired up here (no .monarch_session persistence): the free
+# tier is demo-only. Live Monarch sync is the paid upgrade gate (Phase 3 of the plan).
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-firemaster}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-firemaster}
+      POSTGRES_DB: ${POSTGRES_DB:-firemaster}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-firemaster}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "${REDIS_HOST_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # One-shot: applies Alembic migrations, then (on an empty DB) seeds the demo persona, then
+  # exits. The seed scripts are baked into the image at /app/scripts (the build context is the
+  # repo root — see backend/Dockerfile), so `../scripts/seed_demo.py` resolves with no mount.
+  # Seeing "migrate Exited (0)" in `docker compose ps` is NORMAL.
+  migrate:
+    image: ghcr.io/gdb-mtx/firemaster-backend:latest
+    volumes:
+      - ./backend/.env:/app/backend/.env   # runtime secrets (see header); NOT env_file
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-firemaster}:${POSTGRES_PASSWORD:-firemaster}@postgres:5432/${POSTGRES_DB:-firemaster}
+      DATABASE_URL_SYNC: postgresql://${POSTGRES_USER:-firemaster}:${POSTGRES_PASSWORD:-firemaster}@postgres:5432/${POSTGRES_DB:-firemaster}
+      REDIS_URL: redis://redis:6379/0
+      DEMO_MODE: ${DEMO_MODE:-false}
+      # First boot only: auto-seed the demo persona when the DB is empty. SEED_DEMO=false starts blank.
+      SEED_DEMO: ${SEED_DEMO:-true}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command: ["sh", "-c", "uv run alembic upgrade head && (uv run python ../scripts/seed_demo.py --if-empty || true)"]
+
+  backend:
+    image: ghcr.io/gdb-mtx/firemaster-backend:latest
+    ports:
+      - "${BACKEND_HOST_PORT:-8000}:8000"
+    volumes:
+      - ./backend/.env:/app/backend/.env   # runtime secrets (see header); NOT env_file
+    environment:
+      # Inside the container Postgres/Redis are reached by SERVICE NAME, not localhost.
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-firemaster}:${POSTGRES_PASSWORD:-firemaster}@postgres:5432/${POSTGRES_DB:-firemaster}
+      DATABASE_URL_SYNC: postgresql://${POSTGRES_USER:-firemaster}:${POSTGRES_PASSWORD:-firemaster}@postgres:5432/${POSTGRES_DB:-firemaster}
+      REDIS_URL: redis://redis:6379/0
+      DEMO_MODE: ${DEMO_MODE:-false}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    # No --reload: there's no mounted source to watch (the code is baked into the image).
+    command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000
+
+  celery-worker:
+    image: ghcr.io/gdb-mtx/firemaster-backend:latest
+    volumes:
+      - ./backend/.env:/app/backend/.env   # runtime secrets (see header); NOT env_file
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-firemaster}:${POSTGRES_PASSWORD:-firemaster}@postgres:5432/${POSTGRES_DB:-firemaster}
+      DATABASE_URL_SYNC: postgresql://${POSTGRES_USER:-firemaster}:${POSTGRES_PASSWORD:-firemaster}@postgres:5432/${POSTGRES_DB:-firemaster}
+      REDIS_URL: redis://redis:6379/0
+      DEMO_MODE: ${DEMO_MODE:-false}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    # -I app.tasks.sync_tasks is REQUIRED for task autodiscovery (matches the dev compose).
+    command: uv run celery -A app.tasks.celery_app worker --loglevel=info -I app.tasks.sync_tasks
+
+  celery-beat:
+    image: ghcr.io/gdb-mtx/firemaster-backend:latest
+    volumes:
+      - ./backend/.env:/app/backend/.env   # runtime secrets (see header); NOT env_file
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-firemaster}:${POSTGRES_PASSWORD:-firemaster}@postgres:5432/${POSTGRES_DB:-firemaster}
+      DATABASE_URL_SYNC: postgresql://${POSTGRES_USER:-firemaster}:${POSTGRES_PASSWORD:-firemaster}@postgres:5432/${POSTGRES_DB:-firemaster}
+      REDIS_URL: redis://redis:6379/0
+      DEMO_MODE: ${DEMO_MODE:-false}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    command: uv run celery -A app.tasks.celery_app beat --loglevel=info
+
+  frontend:
+    image: ghcr.io/gdb-mtx/firemaster-frontend:latest
+    ports:
+      - "${FRONTEND_HOST_PORT:-5173}:5173"
+    environment:
+      # The Vite dev server proxies /api SERVER-SIDE (inside this container), so it must
+      # reach the backend by service name, not localhost.
+      VITE_API_URL: http://backend:8000
+    depends_on:
+      - backend
+
+volumes:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,13 @@ services:
   # finish (service_completed_successfully) so the schema always exists before they run.
   # Seeing "migrate Exited (0)" in `docker compose ps` is NORMAL.
   migrate:
+    # Prebuilt image (pulled by `docker compose up`); `build:` is the dev/offline fallback
+    # (`up --build` forces a local build). Context = repo root so the image bakes in
+    # scripts/ + config/ for the standalone seed — see backend/Dockerfile + the runbook.
+    image: ghcr.io/gdb-mtx/firemaster-backend:latest
     build:
-      context: ./backend
+      context: .
+      dockerfile: backend/Dockerfile
     volumes:
       - ./backend:/app/backend
       - /app/backend/.venv
@@ -54,8 +59,13 @@ services:
     command: ["sh", "-c", "uv run alembic upgrade head && (uv run python ../scripts/seed_demo.py --if-empty || true)"]
 
   backend:
+    # Prebuilt image (pulled by `docker compose up`); `build:` is the dev/offline fallback
+    # (`up --build` forces a local build). Context = repo root so the image bakes in
+    # scripts/ + config/ for the standalone seed — see backend/Dockerfile + the runbook.
+    image: ghcr.io/gdb-mtx/firemaster-backend:latest
     build:
-      context: ./backend
+      context: .
+      dockerfile: backend/Dockerfile
     ports:
       - "${BACKEND_HOST_PORT:-8000}:8000"
     volumes:
@@ -86,8 +96,13 @@ services:
     command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
   celery-worker:
+    # Prebuilt image (pulled by `docker compose up`); `build:` is the dev/offline fallback
+    # (`up --build` forces a local build). Context = repo root so the image bakes in
+    # scripts/ + config/ for the standalone seed — see backend/Dockerfile + the runbook.
+    image: ghcr.io/gdb-mtx/firemaster-backend:latest
     build:
-      context: ./backend
+      context: .
+      dockerfile: backend/Dockerfile
     volumes:
       - ./backend:/app/backend
       - /app/backend/.venv          # anon volume: shield the image's Linux venv from the host mount
@@ -108,8 +123,13 @@ services:
     command: uv run celery -A app.tasks.celery_app worker --loglevel=info -I app.tasks.sync_tasks
 
   celery-beat:
+    # Prebuilt image (pulled by `docker compose up`); `build:` is the dev/offline fallback
+    # (`up --build` forces a local build). Context = repo root so the image bakes in
+    # scripts/ + config/ for the standalone seed — see backend/Dockerfile + the runbook.
+    image: ghcr.io/gdb-mtx/firemaster-backend:latest
     build:
-      context: ./backend
+      context: .
+      dockerfile: backend/Dockerfile
     volumes:
       - ./backend:/app/backend
       - /app/backend/.venv          # anon volume: shield the image's Linux venv from the host mount
@@ -129,6 +149,8 @@ services:
     command: uv run celery -A app.tasks.celery_app beat --loglevel=info
 
   frontend:
+    # Prebuilt image (pulled by `docker compose up`); `build:` is the dev/offline fallback.
+    image: ghcr.io/gdb-mtx/firemaster-frontend:latest
     build:
       context: ./frontend
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,9 +59,6 @@ services:
     command: ["sh", "-c", "uv run alembic upgrade head && (uv run python ../scripts/seed_demo.py --if-empty || true)"]
 
   backend:
-    # Prebuilt image (pulled by `docker compose up`); `build:` is the dev/offline fallback
-    # (`up --build` forces a local build). Context = repo root so the image bakes in
-    # scripts/ + config/ for the standalone seed — see backend/Dockerfile + the runbook.
     image: ghcr.io/gdb-mtx/firemaster-backend:latest
     build:
       context: .
@@ -96,9 +93,6 @@ services:
     command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
   celery-worker:
-    # Prebuilt image (pulled by `docker compose up`); `build:` is the dev/offline fallback
-    # (`up --build` forces a local build). Context = repo root so the image bakes in
-    # scripts/ + config/ for the standalone seed — see backend/Dockerfile + the runbook.
     image: ghcr.io/gdb-mtx/firemaster-backend:latest
     build:
       context: .
@@ -123,9 +117,6 @@ services:
     command: uv run celery -A app.tasks.celery_app worker --loglevel=info -I app.tasks.sync_tasks
 
   celery-beat:
-    # Prebuilt image (pulled by `docker compose up`); `build:` is the dev/offline fallback
-    # (`up --build` forces a local build). Context = repo root so the image bakes in
-    # scripts/ + config/ for the standalone seed — see backend/Dockerfile + the runbook.
     image: ghcr.io/gdb-mtx/firemaster-backend:latest
     build:
       context: .
@@ -149,7 +140,6 @@ services:
     command: uv run celery -A app.tasks.celery_app beat --loglevel=info
 
   frontend:
-    # Prebuilt image (pulled by `docker compose up`); `build:` is the dev/offline fallback.
     image: ghcr.io/gdb-mtx/firemaster-frontend:latest
     build:
       context: ./frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     image: postgres:16-alpine
     ports:
       - "${POSTGRES_HOST_PORT:-5432}:5432"
-    env_file:
-      - path: backend/.env
-        required: false
+    # NO env_file: backend/.env — Postgres only reads POSTGRES_* (set below), and pulling in
+    # backend/.env made Compose try to interpolate the `$...` in the bcrypt AUTH_PASSWORD_HASH
+    # ("variable not set" warnings on every up). The official image ignores those keys anyway.
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-firemaster}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-firemaster}
@@ -32,9 +32,14 @@ services:
   # finish (service_completed_successfully) so the schema always exists before they run.
   # Seeing "migrate Exited (0)" in `docker compose ps` is NORMAL.
   migrate:
-    # Prebuilt image (pulled by `docker compose up`); `build:` is the dev/offline fallback
-    # (`up --build` forces a local build). Context = repo root so the image bakes in
-    # scripts/ + config/ for the standalone seed — see backend/Dockerfile + the runbook.
+    # SOLE BUILDER of the shared backend image. `docker compose up` pulls it from GHCR; `build:`
+    # is the dev/offline fallback (`up --build` forces a local build). The other three backend
+    # services (backend, celery-worker, celery-beat) carry ONLY `image:` and reuse what this
+    # builds — they all run after migrate (depends_on: service_completed_successfully). Giving
+    # all four `build:` made Compose's bake builder build the same tag 4× in parallel and race on
+    # export ("image already exists"), breaking the offline `--build` path. One builder = no race.
+    # Context = repo root so the image bakes in scripts/ + config/ for the standalone seed —
+    # see backend/Dockerfile + the runbook.
     image: ghcr.io/gdb-mtx/firemaster-backend:latest
     build:
       context: .
@@ -59,10 +64,8 @@ services:
     command: ["sh", "-c", "uv run alembic upgrade head && (uv run python ../scripts/seed_demo.py --if-empty || true)"]
 
   backend:
+    # image only — reuses what `migrate` builds/pulls (see migrate's note on the single-builder rule)
     image: ghcr.io/gdb-mtx/firemaster-backend:latest
-    build:
-      context: .
-      dockerfile: backend/Dockerfile
     ports:
       - "${BACKEND_HOST_PORT:-8000}:8000"
     volumes:
@@ -93,10 +96,8 @@ services:
     command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
   celery-worker:
+    # image only — reuses what `migrate` builds/pulls (see migrate's note on the single-builder rule)
     image: ghcr.io/gdb-mtx/firemaster-backend:latest
-    build:
-      context: .
-      dockerfile: backend/Dockerfile
     volumes:
       - ./backend:/app/backend
       - /app/backend/.venv          # anon volume: shield the image's Linux venv from the host mount
@@ -117,10 +118,8 @@ services:
     command: uv run celery -A app.tasks.celery_app worker --loglevel=info -I app.tasks.sync_tasks
 
   celery-beat:
+    # image only — reuses what `migrate` builds/pulls (see migrate's note on the single-builder rule)
     image: ghcr.io/gdb-mtx/firemaster-backend:latest
-    build:
-      context: .
-      dockerfile: backend/Dockerfile
     volumes:
       - ./backend:/app/backend
       - /app/backend/.venv          # anon volume: shield the image's Linux venv from the host mount

--- a/docs/CONTAINER_RUNBOOK.md
+++ b/docs/CONTAINER_RUNBOOK.md
@@ -144,11 +144,57 @@ docker compose up            # rebuilds the world; data still there
 
 ## Still open (future, not blocking)
 
-- **Multi-arch prebuilt images:** build amd64 + arm64 images in CI and push to GHCR so
-  `docker compose pull` skips the local build (faster first run, no architecture surprises).
+- ~~**Multi-arch prebuilt images:**~~ **Done** (Jun 2026) — Phase 1 of `strategy/TIERS_PLAN.md`
+  (private repo). `.github/workflows/docker-images.yml` builds amd64 + arm64 backend/frontend
+  images and pushes them to GHCR on push-to-main (path-filtered) + manual dispatch. Both
+  `docker-compose.yml` services now carry an `image:` alongside `build:`, so `docker compose up`
+  **pulls** (`docker compose pull` to refresh) and `up --build` / offline falls back to a local
+  build. See "Prebuilt images" below for the image-build restructure and the standalone compose.
 - ~~**Windows + amd64 acceptance test:**~~ **Done** (Jun 2026). Validated on Azure
   `Standard_D4s_v7` / Windows Server 2025: Docker Desktop + WSL2 nested virt, amd64 images,
   demo auto-seed, scenarios — all passing. No bash/uv/node on the host.
+
+---
+
+## Prebuilt images (GHCR) and the standalone compose
+
+> Phase 1 + the Phase 2 compose file of `strategy/TIERS_PLAN.md` (private repo). The point:
+> decouple *shipping the product* from *shipping the code* — users pull images, they don't clone.
+
+### The workflow — `.github/workflows/docker-images.yml`
+- Two parallel jobs (backend, frontend) → `ghcr.io/gdb-mtx/firemaster-backend` and
+  `…/firemaster-frontend`, each multi-arch (`linux/amd64` + `linux/arm64`).
+- Tags: `latest` (default branch only), `sha-<7char>`, `YYYY.MM.DD`.
+- Trigger: push to `main` (path-filtered to `backend/`, `frontend/`, `scripts/`, `config/`,
+  the compose file, the workflow) + manual `workflow_dispatch`. Auth is the built-in
+  `GITHUB_TOKEN` (needs `packages: write`) — no PAT.
+- **One-time, post-first-run (manual — CI can't do these):** make BOTH GHCR packages **public**
+  (GitHub profile → Packages → each → Settings → visibility → Public) so pulls need no login.
+
+### Image-build restructure (backend only)
+The backend image's build context is now the **repo root**, not `./backend`
+(`build: { context: ., dockerfile: backend/Dockerfile }`; the workflow matches). Why: the
+standalone compose can't bind-mount `scripts/` + `config/`, so the demo first-run seed
+(`../scripts/seed_demo.py`) would have nothing to run. The Dockerfile now `COPY`s `backend/`,
+`scripts`, and `config` into the image; a new **root `.dockerignore`** keeps everything else
+(frontend, `.git`, venvs, **secrets**) out of the larger context. The dev compose still
+bind-mounts `./scripts` + `./config` over the baked copies, so native edit-reload is unchanged.
+- **Verify the bake:** `docker build -f backend/Dockerfile -t fm-test . && docker run --rm
+  fm-test ls /app/scripts /app/config` → the seed scripts + config files are listed.
+- **Gotcha:** never let `backend/.env` into the image — the root `.dockerignore` excludes
+  `**/.env`; if you ever see login break on a *pulled* image, confirm that exclusion held.
+
+### Standalone compose — `docker-compose.public.yml`
+The file shipped in the install kit (firemaster.io): GHCR images only, **no `build:`**, **no
+source bind-mounts**, no `scripts/`/`config/` on disk (they're in the image). Run it with
+`-f docker-compose.public.yml`. Differences from the dev compose worth knowing:
+- **`.env` is a single-file bind mount** (`./backend/.env:/app/backend/.env`), not `env_file`
+  (the interpolation bug — see the troubleshooting table). A bind mount of a **non-existent**
+  host file is created as a *directory*, which breaks `app.setup`, so the kit must ship an
+  empty `backend/.env` placeholder that the setup step fills in.
+- **No Monarch persistence** (no `.monarch_session` volume): the free tier is demo-only; live
+  sync is the paid gate (Phase 3, not yet built).
+- Pull/update: `docker compose -f docker-compose.public.yml pull && … up -d`.
 
 ---
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -1,7 +1,7 @@
 # Setup Guide
 
-Complete walkthrough from clone to a living dashboard. Expect **10–20 minutes** end to end,
-most of it the one-time Docker image build. The short version is in the
+Complete walkthrough from clone to a living dashboard. Expect **~10 minutes** end to end —
+mostly the prebuilt-image pull and Docker Desktop install. The short version is in the
 [README](../README.md#quick-start); this guide adds detail, expected output, and the
 post-install configuration steps.
 
@@ -61,7 +61,9 @@ host dependencies and it works identically on Windows.
 docker compose up
 ```
 
-First run **builds the images** (a few minutes) and pulls Postgres/Redis. Then, every start:
+First run **pulls the prebuilt images** from GHCR (~30–60s) plus Postgres/Redis. (No prebuilt
+image available, or offline? `docker compose up --build` builds them locally instead — a few
+minutes.) Then, every start:
 
 1. **postgres** and **redis** come up and pass health checks,
 2. a one-shot **migrate** service runs `alembic upgrade head` — on a fresh database this builds
@@ -139,6 +141,13 @@ Everything the projections assume lives in one place: **Settings → Plan** (bas
   The seeded examples in `scripts/seed_scenarios.py` show the full key set.
 
 ## 8. Staying up to date
+
+```bash
+docker compose pull               # fetch the latest prebuilt images from GHCR
+docker compose up -d              # restart on them; migrate auto-applies any new migrations
+```
+
+Contributors developing against the source tree update with a local rebuild instead:
 
 ```bash
 git pull


### PR DESCRIPTION
Executes Phase 1 + the Phase 2 compose file of the distribution-tiers plan: ship images, not code.

## What's here
- **GHCR build workflow** — multi-arch (amd64+arm64) backend/frontend images, tags `latest`/`sha-`/date. Fires on push to `main`.
- **`docker-compose.yml`** — `image:` on all build services, so `up` pulls and `up --build` still builds.
- **Backend image** — build context moved to repo root so `scripts/` + `config/` get baked in (the standalone compose can't bind-mount them and needs them for the demo seed). New root `.dockerignore`.
- **`docker-compose.public.yml`** — no-clone standalone stack: GHCR images only, no source mounts, demo seeds from the baked-in scripts.
- Docs switched to the `docker compose pull` path.

⚠️ The image build is **untested** — no Docker daemon in the session. First CI run is its first real exercise (watch the arm64 build).

## Merge, then do these (manual — CI can't):
- [ ] Watch the Actions run go green
- [ ] Make **both** GHCR packages public (Profile → Packages → each → Settings → visibility → Public)
- [ ] Fresh dir: `docker compose pull && up` — confirm it pulls, not builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSvx8cvp28wPv1jQy7A8ZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSvx8cvp28wPv1jQy7A8ZR)_